### PR TITLE
Improve text mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The current version targets Minecraft version **16w32b**.
 
 ## Contributing
 
-Download Enigma from [here](http://modmuss50.me:8080/job/Enigma-Asie/) ([source](https://github.com/ChorusMC/Enigma)). Use the "-all" JAR.
+Download Enigma from [here](http://modmuss50.me:8080/job/Chorus/job/Enigma-Chorus/) ([source](https://github.com/ChorusMC/Enigma)). Use the "-all" JAR.
 
 Please remember that copying and pasting mappings from alternate projects under more restrictive licenses (such as MCP) is **completely forbidden**. It is also good to consult name changes with other people via pull requests.
 

--- a/mappings/net/minecraft/text/ScoreComponent.mapping
+++ b/mappings/net/minecraft/text/ScoreComponent.mapping
@@ -1,4 +1,4 @@
-CLASS none/fd net/minecraft/text/impl/TextComponentScore
+CLASS none/fd net/minecraft/text/ScoreComponent
 	METHOD e getText ()Ljava/lang/String;
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 0 other

--- a/mappings/net/minecraft/text/SelectorComponent.mapping
+++ b/mappings/net/minecraft/text/SelectorComponent.mapping
@@ -1,4 +1,4 @@
-CLASS none/fe net/minecraft/text/impl/TextComponentSelector
+CLASS none/fe net/minecraft/text/SelectorComponent
 	FIELD b pattern Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 0 pattern

--- a/mappings/net/minecraft/text/TextComponent.mapping
+++ b/mappings/net/minecraft/text/TextComponent.mapping
@@ -1,4 +1,4 @@
-CLASS none/fg net/minecraft/text/impl/TextComponentString
+CLASS none/fg net/minecraft/text/TextComponent
 	FIELD b text Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 0 text

--- a/mappings/net/minecraft/text/TranslatableComponent.mapping
+++ b/mappings/net/minecraft/text/TranslatableComponent.mapping
@@ -1,4 +1,4 @@
-CLASS none/fh net/minecraft/text/impl/TextComponentTranslatable
+CLASS none/fh net/minecraft/text/TranslatableComponent
 	FIELD d key Ljava/lang/String;
 	FIELD e args [Ljava/lang/Object;
 	METHOD <init> (Ljava/lang/String;[Ljava/lang/Object;)V

--- a/mappings/net/minecraft/text/event/ClickEvent.mapping
+++ b/mappings/net/minecraft/text/event/ClickEvent.mapping
@@ -1,4 +1,4 @@
-CLASS none/ez net/minecraft/text/ClickEvent
+CLASS none/ez net/minecraft/text/event/ClickEvent
 	CLASS none/ez$a Action
 		FIELD a OPEN_URL Lnone/ez$a;
 		FIELD b OPEN_FILE Lnone/ez$a;

--- a/mappings/net/minecraft/text/event/HoverEvent.mapping
+++ b/mappings/net/minecraft/text/event/HoverEvent.mapping
@@ -1,4 +1,4 @@
-CLASS none/fc net/minecraft/text/HoverEvent
+CLASS none/fc net/minecraft/text/event/HoverEvent
 	CLASS none/fc$a Action
 		FIELD a SHOW_TEXT Lnone/fc$a;
 		FIELD b SHOW_ACHIEVEMENT Lnone/fc$a;


### PR DESCRIPTION
- Mojang give away many mappings for free via their #toString() we should use those

- impl packages are horrid

- net/minecraft/text/event vs net/minecraft/event/text

- AbstractTextComponent vs TextComponentBase

- TextStyle vs Style